### PR TITLE
feat: context validity windows — TTL annotations, soft decay, openfuse validate

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import * as registry from "./registry.js";
 import { fingerprint } from "./crypto.js";
 import { resolve, join } from "node:path";
 import { readFile } from "node:fs/promises";
+import { parseValiditySections, buildValidityReport } from "./validity.js";
 
 const VERSION = "0.3.10";
 
@@ -298,13 +299,77 @@ program
   .command("compact")
   .description("Move [DONE] sections from CONTEXT.md to history/")
   .option("-d, --dir <path>", "Context store directory", ".")
+  .option("--prune-stale", "Also archive sections past their <!-- validity: --> window (confidence < 0.1)")
   .action(async (opts) => {
     const store = new ContextStore(resolve(opts.dir));
+    let prunedCount = 0;
+
+    if (opts.pruneStale) {
+      // Soft-expiry pruning: rewrite CONTEXT.md with stale sections stripped
+      const content = await store.readContext();
+      const sections = parseValiditySections(content);
+      const staleSections = sections.filter((s) => s.expired);
+
+      if (staleSections.length > 0) {
+        // Remove stale annotated sections from file
+        let updated = content;
+        for (const s of staleSections) {
+          // Strip the section text from the file (simple text removal)
+          updated = updated.replace(s.sectionText, "[STALE — archived by openfuse compact --prune-stale]");
+        }
+        await store.writeContext(updated);
+        prunedCount = staleSections.length;
+      }
+    }
+
     const { moved, kept } = await store.compactContext();
-    if (moved === 0) {
+    if (moved === 0 && prunedCount === 0) {
       console.log("Nothing to compact. Mark sections with [DONE] to archive them.");
     } else {
-      console.log(`Compacted: ${moved} done, ${kept} kept.`);
+      const parts: string[] = [];
+      if (moved > 0) parts.push(`${moved} done`);
+      if (prunedCount > 0) parts.push(`${prunedCount} stale`);
+      console.log(`Compacted: ${parts.join(", ")}, ${kept} kept.`);
+    }
+  });
+
+// --- validate ---
+program
+  .command("validate")
+  .description("Scan CONTEXT.md for expired validity windows and report stale entries")
+  .option("-d, --dir <path>", "Context store directory", ".")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const store = new ContextStore(resolve(opts.dir));
+    if (!(await store.exists())) {
+      console.error("No context store found. Run `openfuse init` first.");
+      process.exit(1);
+    }
+    const content = await store.readContext();
+    const sections = parseValiditySections(content);
+    const report = buildValidityReport(sections);
+
+    if (opts.json) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+
+    if (report.total === 0) {
+      console.log("No validity-annotated sections found.");
+      console.log("Add `<!-- validity: 6h -->` before time-sensitive context entries.");
+      return;
+    }
+
+    console.log(`Validity check: ${report.fresh} fresh, ${report.stale} stale (of ${report.total} annotated)`);
+    if (report.stale > 0) {
+      console.log("\nStale sections (confidence < 0.1):");
+      for (const e of report.entries.filter((e) => e.expired)) {
+        const age = e.addedAt ? ` written ${e.addedAt}` : "";
+        console.log(`  [${e.ttlLabel} TTL${age}] ${e.preview}`);
+      }
+      console.log("\nRun `openfuse compact --prune-stale` to archive stale sections.");
+    } else {
+      console.log("All annotated sections are within their validity windows. ✓");
     }
   });
 

--- a/src/validity.test.ts
+++ b/src/validity.test.ts
@@ -1,0 +1,229 @@
+// Tests for context validity window module
+// Run: node --import tsx/esm src/validity.test.ts
+// (or after build: node dist/validity.test.js)
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseTtlMs,
+  computeConfidence,
+  parseValiditySections,
+  buildValidityReport,
+  DEFAULT_TTL_TIERS,
+} from "./validity.js";
+
+// --- parseTtlMs ---
+
+describe("parseTtlMs", () => {
+  it("parses hours", () => {
+    assert.equal(parseTtlMs("6", "h"), 6 * 60 * 60 * 1000);
+  });
+  it("parses days", () => {
+    assert.equal(parseTtlMs("3", "d"), 3 * 24 * 60 * 60 * 1000);
+  });
+  it("parses 1d", () => {
+    assert.equal(parseTtlMs("1", "d"), 24 * 60 * 60 * 1000);
+  });
+  it("parses 24h", () => {
+    assert.equal(parseTtlMs("24", "H"), 24 * 60 * 60 * 1000);
+  });
+});
+
+// --- computeConfidence ---
+
+describe("computeConfidence", () => {
+  const ttl6h = 6 * 60 * 60 * 1000;
+
+  it("returns 1.0 when no addedAt (no timestamp)", () => {
+    assert.equal(computeConfidence(undefined, ttl6h), 1.0);
+  });
+
+  it("returns 1.0 at write time", () => {
+    const now = new Date("2026-03-21T12:00:00Z");
+    const addedAt = new Date("2026-03-21T12:00:00Z");
+    assert.equal(computeConfidence(addedAt, ttl6h, now), 1.0);
+  });
+
+  it("returns 0.5 at TTL boundary", () => {
+    const addedAt = new Date("2026-03-21T00:00:00Z");
+    const now = new Date("2026-03-21T06:00:00Z"); // exactly 6h later
+    const conf = computeConfidence(addedAt, ttl6h, now);
+    assert.ok(Math.abs(conf - 0.5) < 0.0001, `expected ~0.5, got ${conf}`);
+  });
+
+  it("returns ~0.25 at 2× TTL", () => {
+    const addedAt = new Date("2026-03-21T00:00:00Z");
+    const now = new Date("2026-03-21T12:00:00Z"); // 12h = 2× TTL
+    const conf = computeConfidence(addedAt, ttl6h, now);
+    assert.ok(Math.abs(conf - 0.25) < 0.0001, `expected ~0.25, got ${conf}`);
+  });
+
+  it("returns < 0.1 at 3.32× TTL (expired threshold)", () => {
+    const addedAt = new Date("2026-03-21T00:00:00Z");
+    const now = new Date("2026-03-21T20:00:00Z"); // 20h ≈ 3.33× TTL
+    const conf = computeConfidence(addedAt, ttl6h, now);
+    assert.ok(conf < 0.1, `expected < 0.1, got ${conf}`);
+  });
+
+  it("handles future addedAt gracefully (returns 1.0)", () => {
+    const addedAt = new Date("2026-03-22T00:00:00Z");
+    const now = new Date("2026-03-21T12:00:00Z");
+    assert.equal(computeConfidence(addedAt, ttl6h, now), 1.0);
+  });
+});
+
+// --- parseValiditySections ---
+
+describe("parseValiditySections", () => {
+  it("returns empty array when no validity annotations", () => {
+    const content = "# Context\n\nWorking on: auth refactor\n";
+    const sections = parseValiditySections(content);
+    assert.equal(sections.length, 0);
+  });
+
+  it("parses a single validity section with addedAt", () => {
+    const addedAt = "2026-03-21T10:00:00Z";
+    const now = new Date("2026-03-21T13:00:00Z"); // 3h after write
+    const content = [
+      "<!-- validity: 6h -->",
+      `<!-- openfuse:added: ${addedAt} -->`,
+      "Working on: auth refactor",
+      "Blocked on: IAM role",
+    ].join("\n");
+    const sections = parseValiditySections(content, now);
+    assert.equal(sections.length, 1);
+    assert.equal(sections[0].ttlMs, 6 * 60 * 60 * 1000);
+    // toISOString() returns .000Z suffix; just check the date round-trips
+    assert.ok(sections[0].addedAt instanceof Date);
+    assert.equal(sections[0].addedAt!.getTime(), new Date(addedAt).getTime());
+    assert.ok(sections[0].confidence > 0.5, "should be > 0.5 at 3h of 6h TTL");
+    assert.equal(sections[0].expired, false);
+    assert.ok(sections[0].sectionText.includes("auth refactor"));
+  });
+
+  it("parses a section without addedAt (confidence = 1.0)", () => {
+    const content = [
+      "<!-- validity: 1d -->",
+      "Architecture: JWT with 15-minute expiry",
+    ].join("\n");
+    const sections = parseValiditySections(content);
+    assert.equal(sections.length, 1);
+    assert.equal(sections[0].addedAt, undefined);
+    assert.equal(sections[0].confidence, 1.0);
+    assert.equal(sections[0].expired, false);
+  });
+
+  it("marks expired sections correctly", () => {
+    const addedAt = "2026-03-20T00:00:00Z"; // 48h ago
+    const now = new Date("2026-03-22T00:00:00Z");
+    const content = [
+      "<!-- validity: 6h -->",
+      `<!-- openfuse:added: ${addedAt} -->`,
+      "Blocked on: IAM role",
+    ].join("\n");
+    const sections = parseValiditySections(content, now);
+    assert.equal(sections.length, 1);
+    assert.equal(sections[0].expired, true);
+    assert.ok(sections[0].confidence < 0.1);
+  });
+
+  it("parses multiple validity sections independently", () => {
+    const now = new Date("2026-03-22T00:00:00Z");
+    const freshAdded = "2026-03-21T23:00:00Z"; // 1h ago — fresh vs 6h TTL
+    const staleAdded = "2026-03-18T00:00:00Z";  // 96h ago — expired vs 24h TTL (0.5^4 = 0.0625 < 0.1)
+    const content = [
+      "# Context",
+      "",
+      "<!-- validity: 6h -->",
+      `<!-- openfuse:added: ${freshAdded} -->`,
+      "Working on: auth refactor",
+      "",
+      "<!-- validity: 1d -->",
+      `<!-- openfuse:added: ${staleAdded} -->`,
+      "Sprint goal: ship auth by Friday",
+    ].join("\n");
+    const sections = parseValiditySections(content, now);
+    assert.equal(sections.length, 2);
+    assert.equal(sections[0].expired, false);
+    assert.equal(sections[1].expired, true);
+  });
+
+  it("parses validity with component annotation", () => {
+    const content = [
+      "<!-- validity: 6h, component: auth-gateway -->",
+      "Working on: JWT refactor",
+    ].join("\n");
+    const sections = parseValiditySections(content);
+    assert.equal(sections.length, 1);
+    assert.equal(sections[0].ttlMs, 6 * 60 * 60 * 1000);
+  });
+
+  it("parses day-based TTL", () => {
+    const content = [
+      "<!-- validity: 3d -->",
+      "Architecture: microservices with shared auth layer",
+    ].join("\n");
+    const sections = parseValiditySections(content);
+    assert.equal(sections.length, 1);
+    assert.equal(sections[0].ttlMs, 3 * 24 * 60 * 60 * 1000);
+  });
+});
+
+// --- buildValidityReport ---
+
+describe("buildValidityReport", () => {
+  it("returns correct counts for mixed fresh/stale", () => {
+    const now = new Date("2026-03-22T00:00:00Z");
+    const freshAdded = "2026-03-21T23:00:00Z";
+    const staleAdded = "2026-03-20T00:00:00Z";
+    const content = [
+      "<!-- validity: 6h -->",
+      `<!-- openfuse:added: ${freshAdded} -->`,
+      "Working on: auth refactor",
+      "",
+      "<!-- validity: 6h -->",
+      `<!-- openfuse:added: ${staleAdded} -->`,
+      "Blocked on: IAM role (OLD)",
+    ].join("\n");
+    const sections = parseValiditySections(content, now);
+    const report = buildValidityReport(sections);
+    assert.equal(report.total, 2);
+    assert.equal(report.fresh, 1);
+    assert.equal(report.stale, 1);
+  });
+
+  it("formats ttlLabel correctly for hours and days", () => {
+    const content = [
+      "<!-- validity: 6h -->",
+      "Task context",
+      "",
+      "<!-- validity: 1d -->",
+      "Sprint context",
+      "",
+      "<!-- validity: 3d -->",
+      "Architecture context",
+    ].join("\n");
+    const sections = parseValiditySections(content);
+    const report = buildValidityReport(sections);
+    assert.equal(report.entries[0].ttlLabel, "6h");
+    assert.equal(report.entries[1].ttlLabel, "1d");
+    assert.equal(report.entries[2].ttlLabel, "3d");
+  });
+
+  it("truncates long section previews to 80 chars", () => {
+    const longLine = "A".repeat(100);
+    const content = `<!-- validity: 6h -->\n${longLine}`;
+    const sections = parseValiditySections(content);
+    const report = buildValidityReport(sections);
+    assert.ok(report.entries[0].preview.length <= 80);
+  });
+});
+
+// --- DEFAULT_TTL_TIERS ---
+
+describe("DEFAULT_TTL_TIERS", () => {
+  it("has expected values", () => {
+    assert.equal(DEFAULT_TTL_TIERS.task, 6 * 60 * 60 * 1000);
+    assert.equal(DEFAULT_TTL_TIERS.sprint, 24 * 60 * 60 * 1000);
+    assert.equal(DEFAULT_TTL_TIERS.architecture, 72 * 60 * 60 * 1000);
+  });
+});

--- a/src/validity.ts
+++ b/src/validity.ts
@@ -1,0 +1,165 @@
+// --- Context validity windows ---
+// Agents often write context that's only valid for a bounded time window.
+// This module parses `<!-- validity: Xh -->` (or `1d`, `3d`) annotations
+// from CONTEXT.md, checks freshness against `<!-- openfuse:added: ISO -->`,
+// and provides soft-expiry confidence scoring via exponential decay.
+//
+// Design decisions:
+// - Advisory only: agents that don't understand validity annotations read
+//   CONTEXT.md normally. No schema enforcement.
+// - Decay starts at write time, reaches 0.5 at TTL, asymptotes toward 0.
+//   Agents can down-weight uncertain context rather than hard-drop it.
+// - "Stale" means confidence < 0.1 (roughly 3× TTL from write time).
+
+export interface ValidityAnnotation {
+  /** Validity window parsed from <!-- validity: ... --> */
+  ttlMs: number;
+  /** Written timestamp from <!-- openfuse:added: ISO --> (if present) */
+  addedAt?: Date;
+  /** True if confidence < 0.1 */
+  expired: boolean;
+  /** Soft confidence [0, 1]. 1.0 at write time, 0.5 at TTL, asymptotes to 0 */
+  confidence: number;
+  /** The section text following this annotation (until the next annotation or EOF) */
+  sectionText: string;
+}
+
+export interface ValidityReport {
+  total: number;
+  stale: number;
+  fresh: number;
+  entries: Array<{
+    preview: string;
+    addedAt: string | null;
+    ttlLabel: string;
+    confidence: number;
+    expired: boolean;
+  }>;
+}
+
+// --- Parsing ---
+
+const VALIDITY_RE = /<!--\s*validity:\s*(\d+)\s*(h|d)\s*(?:,\s*[^>]*)?\s*-->/i;
+const ADDED_RE = /<!--\s*openfuse:added:\s*([^\s>]+)\s*-->/i;
+
+/** Parse a TTL label like "6h" or "3d" into milliseconds */
+export function parseTtlMs(value: string, unit: string): number {
+  const n = parseInt(value, 10);
+  if (unit.toLowerCase() === "d") return n * 24 * 60 * 60 * 1000;
+  return n * 60 * 60 * 1000; // hours default
+}
+
+/** Soft-expiry confidence. Exponential decay: 1.0 at write, 0.5 at TTL, →0 over time. */
+export function computeConfidence(
+  addedAt: Date | undefined,
+  ttlMs: number,
+  now: Date = new Date()
+): number {
+  if (!addedAt) {
+    // No timestamp — treat as written "now" with full confidence
+    return 1.0;
+  }
+  const ageMs = now.getTime() - addedAt.getTime();
+  if (ageMs <= 0) return 1.0;
+  // Exponential decay: confidence = 0.5 ^ (age / ttl)
+  return Math.pow(0.5, ageMs / ttlMs);
+}
+
+/**
+ * Parse CONTEXT.md content for validity-annotated sections.
+ * Each `<!-- validity: Xh -->` comment starts a new annotated section.
+ * Sections without validity annotations are skipped.
+ */
+export function parseValiditySections(
+  content: string,
+  now: Date = new Date()
+): ValidityAnnotation[] {
+  const results: ValidityAnnotation[] = [];
+  const lines = content.split("\n");
+
+  let inSection = false;
+  let currentTtlMs = 0;
+  let currentAddedAt: Date | undefined;
+  let sectionLines: string[] = [];
+
+  const flushSection = () => {
+    if (!inSection) return;
+    const confidence = computeConfidence(currentAddedAt, currentTtlMs, now);
+    results.push({
+      ttlMs: currentTtlMs,
+      addedAt: currentAddedAt,
+      expired: confidence < 0.1,
+      confidence,
+      sectionText: sectionLines.join("\n").trim(),
+    });
+    inSection = false;
+    sectionLines = [];
+    currentAddedAt = undefined;
+    currentTtlMs = 0;
+  };
+
+  for (const line of lines) {
+    const validityMatch = line.match(VALIDITY_RE);
+    if (validityMatch) {
+      flushSection();
+      currentTtlMs = parseTtlMs(validityMatch[1], validityMatch[2]);
+      inSection = true;
+      continue;
+    }
+
+    const addedMatch = line.match(ADDED_RE);
+    if (addedMatch && inSection && !currentAddedAt) {
+      const parsed = new Date(addedMatch[1]);
+      if (!isNaN(parsed.getTime())) {
+        currentAddedAt = parsed;
+      }
+      continue;
+    }
+
+    if (inSection) {
+      sectionLines.push(line);
+    }
+  }
+
+  flushSection();
+  return results;
+}
+
+/** Build a human-readable report of validity window status */
+export function buildValidityReport(
+  sections: ValidityAnnotation[]
+): ValidityReport {
+  const entries = sections.map((s) => {
+    const preview =
+      s.sectionText.split("\n").find((l) => l.trim()) ?? "(empty)";
+    const ttlMs = s.ttlMs;
+    const hours = ttlMs / (60 * 60 * 1000);
+    const ttlLabel =
+      hours >= 24 ? `${Math.round(hours / 24)}d` : `${Math.round(hours)}h`;
+    return {
+      preview: preview.slice(0, 80),
+      addedAt: s.addedAt ? s.addedAt.toISOString() : null,
+      ttlLabel,
+      confidence: Math.round(s.confidence * 100) / 100,
+      expired: s.expired,
+    };
+  });
+
+  return {
+    total: sections.length,
+    stale: sections.filter((s) => s.expired).length,
+    fresh: sections.filter((s) => !s.expired).length,
+    entries,
+  };
+}
+
+// --- Default TTL tiers (from multi-agent swarm research) ---
+// Based on 20-agent, 20-run PDR evaluation dataset:
+//   task-state context (what I'm working on right now): ~6h half-life
+//   sprint-context (sprint goals, current approach): ~24h half-life
+//   project-architecture (design decisions, constraints): ~72h half-life
+export const DEFAULT_TTL_TIERS = {
+  task: 6 * 60 * 60 * 1000,        // 6h
+  sprint: 24 * 60 * 60 * 1000,     // 24h
+  architecture: 72 * 60 * 60 * 1000, // 72h
+} as const;


### PR DESCRIPTION
Implements context validity windows for CONTEXT.md, following the discussion in #1 and building on the v0.3.6 auto-timestamp + `[DONE]` compaction foundation.

## Problem solved

Agents treat context as timeless when it's inherently temporal. Another agent syncing a `CONTEXT.md` from 6 hours ago acts on stale state. The `<!-- openfuse:added: ISO -->` timestamp from v0.3.6 gives us the write time — this PR adds the TTL layer on top.

## Changes

### `src/validity.ts` (new)
- `parseTtlMs()` — parse `6h`, `1d`, `3d` TTL strings to milliseconds
- `computeConfidence(addedAt, ttlMs, now)` — exponential decay: 1.0 at write time, 0.5 at TTL, asymptotes toward 0. Reads `<!-- openfuse:added: ISO -->` timestamps from the existing auto-timestamp infrastructure
- `parseValiditySections(content)` — parse CONTEXT.md for `<!-- validity: Xh/Xd -->` annotated sections with freshness status  
- `buildValidityReport(sections)` — human-readable freshness summary
- Default TTL tiers from multi-agent swarm research: task-state 6h / sprint-context 24h / project-architecture 72h

### `openfuse validate` (new CLI command)
Scan CONTEXT.md for expired validity windows:
```
$ openfuse validate
Validity check: 2 fresh, 1 stale (of 3 annotated)
Stale sections (confidence < 0.1):
  [6h TTL written 2026-03-21T14:00Z] Blocked on: IAM role (OLD)
Run `openfuse compact --prune-stale` to archive stale sections.

$ openfuse validate --json   # machine-readable output
```

### `openfuse compact --prune-stale` (new flag)
Archives sections past their validity window (confidence < 0.1), complementing the existing `[DONE]` compaction mechanism.

### `src/validity.test.ts` (new, 21 tests)
Uses `node:test` (no external dependencies). Covers: TTL parsing, confidence decay curve boundary conditions, section parsing, expiry detection, multi-section independence, report generation.

```
# pass 21
# fail 0
```

## Usage

```markdown
<!-- validity: 6h -->
<!-- openfuse:added: 2026-03-22T05:00:00Z -->
Working on: authentication refactor for the API gateway
Blocked on: AWS IAM role permissions

<!-- validity: 3d -->
<!-- openfuse:added: 2026-03-22T05:00:00Z -->
Architecture: microservices with shared auth layer
```

## Design decisions

- **Advisory only** — agents without validity support read CONTEXT.md normally. No schema enforcement.
- **Decay starts at write time** (`openfuse:added` timestamp), reaches 0.5 at TTL, asymptotes toward 0. Agents can down-weight uncertain context rather than hard-drop it.
- **Expired threshold is confidence < 0.1** (roughly 3.3× TTL from write time). There's a long grace period between 'partially stale' and 'fully expired'.
- **No timestamp = confidence 1.0** — sections without `openfuse:added` are treated as fully fresh (conservative, non-breaking for existing content).

On the soft-expiry design question I asked in the issue: decay starts at write time (`openfuse:added`), reaches 0.5 at TTL. This means entries are down-weighted before they're fully expired, giving reading agents a signal gradient rather than a cliff.

Closes #1