### PR TITLE
feat: add HTTP proxy support to CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openfused",
-  "version": "0.3.1",
+  "version": "0.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openfused",
-      "version": "0.3.1",
+      "version": "0.3.13",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -14,6 +14,7 @@
         "chokidar": "^5.0.0",
         "commander": "^14.0.0",
         "nanoid": "^5.1.7",
+        "undici": "^7.24.5",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -1248,6 +1249,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chokidar": "^5.0.0",
     "commander": "^14.0.0",
     "nanoid": "^5.1.7",
+    "undici": "^7.24.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,19 @@ import { resolve, join } from "node:path";
 import { readFile } from "node:fs/promises";
 import { parseValiditySections, buildValidityReport } from "./validity.js";
 
+// Enable proxy support: Node.js built-in fetch (undici) doesn't respect
+// HTTP_PROXY/HTTPS_PROXY env vars by default. Setting a global EnvHttpProxyAgent
+// makes all fetch() calls proxy-aware, which is essential for corporate networks,
+// containers, and tunneled environments.
+if (process.env.https_proxy || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.HTTP_PROXY) {
+  try {
+    const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+  } catch {
+    // undici not available — fetch will work without proxy
+  }
+}
+
 const VERSION = "0.3.13";
 
 const program = new Command();


### PR DESCRIPTION
Node.js built-in fetch (undici) doesn't respect HTTP_PROXY/HTTPS_PROXY env vars by default. This adds an EnvHttpProxyAgent at startup so the CLI works in corporate networks, containers, and tunneled environments.

https://claude.ai/code/session_01Dd7gFk7RTJ4Y3rUWC1GEUo